### PR TITLE
Utility class for converting between native and 310 data types

### DIFF
--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/ThreeTenUtil.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/ThreeTenUtil.java
@@ -1,0 +1,21 @@
+package com.jakewharton.threetenabp;
+
+import org.threeten.bp.Instant;
+import org.threeten.bp.LocalDate;
+import org.threeten.bp.ZoneId;
+
+import java.util.Date;
+
+/**
+ * Helper methods for converting between Android-Java and ThreeTenABP data types
+ */
+public class ThreeTenUtil {
+
+    public static Date asDate(LocalDate localDate) {
+        return new Date(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
+    }
+
+    public static LocalDate asLocalDate(Date date) {
+        return Instant.ofEpochMilli(date.getTime()).atZone(ZoneId.systemDefault()).toLocalDate();
+    }
+}


### PR DESCRIPTION
I was thinking something like this could be useful to have, this is just kicking it off with the ones I've already written for my project. 

On the JDK it's a bit easier to do the conversions, because helper methods have been added to the old data-types, like Date.toInstant() and Date.fromInstant(), but that's missing on Android. 
It's also easy to get the conversion wrong as Stephen explains [here]( http://stackoverflow.com/questions/21242110/convert-java-util-date-to-java-time-localdate), so would be good to provide a way of doing this correctly, specific to Android. 

What do you think?