### PR TITLE
Include a ProGuard file with the library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.3'
+    classpath 'com.android.tools.build:gradle:1.3.0'
   }
 }
 
@@ -21,4 +21,5 @@ ext {
   junit = 'junit:junit:4.12'
   truth = 'com.google.truth:truth:0.27'
   supportTestRunner = 'com.android.support.test:runner:0.3'
+  supportTestRules = 'com.android.support.test:rules:0.3'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'com.android.application'
+
+dependencies {
+  compile project(':threetenabp')
+
+  androidTestCompile rootProject.ext.junit
+  androidTestCompile rootProject.ext.supportTestRunner
+  androidTestCompile rootProject.ext.supportTestRules
+}
+
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
+
+  defaultConfig {
+    applicationId 'com.jakewharton.threetenabp.sample'
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion 22
+    versionCode 1
+    versionName '1.0'
+
+    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+  }
+
+  buildTypes {
+    debug {
+      minifyEnabled true
+      proguardFiles getDefaultProguardFile('proguard-android.txt')
+      testProguardFiles file('test-proguard-rules.pro')
+    }
+  }
+}

--- a/sample/src/androidTest/java/com/jakewharton/threetenabp/sample/ExamplesTest.java
+++ b/sample/src/androidTest/java/com/jakewharton/threetenabp/sample/ExamplesTest.java
@@ -1,0 +1,26 @@
+package com.jakewharton.threetenabp.sample;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.threeten.bp.Instant;
+
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(AndroidJUnit4.class)
+public final class ExamplesTest {
+  @Rule public final ActivityTestRule<Examples> examplesActivity =
+      new ActivityTestRule<>(Examples.class);
+
+  /**
+   * Assert that ProGuard has run and obfuscated a library type. This implicitly also tests the
+   * embedded ProGuard rules in the library are correct since currently ProGuard fails without them.
+   */
+  @Test public void proguardHappened() {
+    Examples activity = examplesActivity.getActivity();
+    Instant now = activity.now();
+    assertNotEquals("Instant", now.getClass().getSimpleName());
+  }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.jakewharton.threetenabp.sample"
+    >
+  <application
+      android:name=".ExamplesApp"
+      android:label="ThreeTenABP"
+      >
+    <activity android:name=".Examples">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/sample/src/main/java/com/jakewharton/threetenabp/sample/Examples.java
+++ b/sample/src/main/java/com/jakewharton/threetenabp/sample/Examples.java
@@ -1,0 +1,25 @@
+package com.jakewharton.threetenabp.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.TextView;
+import org.threeten.bp.Instant;
+
+import static android.util.TypedValue.COMPLEX_UNIT_SP;
+import static android.view.Gravity.CENTER;
+
+public final class Examples extends Activity {
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    TextView tv = new TextView(this);
+    tv.setGravity(CENTER);
+    tv.setTextSize(COMPLEX_UNIT_SP, 20);
+    tv.setText("NOW: " + now());
+    setContentView(tv);
+  }
+
+  public Instant now() {
+    return Instant.now();
+  }
+}

--- a/sample/src/main/java/com/jakewharton/threetenabp/sample/ExamplesApp.java
+++ b/sample/src/main/java/com/jakewharton/threetenabp/sample/ExamplesApp.java
@@ -1,0 +1,11 @@
+package com.jakewharton.threetenabp.sample;
+
+import android.app.Application;
+import com.jakewharton.threetenabp.AndroidThreeTen;
+
+public final class ExamplesApp extends Application {
+  @Override public void onCreate() {
+    super.onCreate();
+    AndroidThreeTen.init(this);
+  }
+}

--- a/sample/test-proguard-rules.pro
+++ b/sample/test-proguard-rules.pro
@@ -1,0 +1,3 @@
+-dontwarn org.junit.**
+-dontwarn android.test.**
+-dontwarn android.support.test.**

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include ':threetenabp'
+include ':sample'

--- a/threetenabp/build.gradle
+++ b/threetenabp/build.gradle
@@ -30,6 +30,12 @@ android {
   dexOptions {
     preDexLibraries = !isCi()
   }
+
+  buildTypes {
+    release {
+      consumerProguardFiles file('consumer-proguard-rules.pro')
+    }
+  }
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/threetenabp/consumer-proguard-rules.pro
+++ b/threetenabp/consumer-proguard-rules.pro
@@ -1,0 +1,2 @@
+# TODO https://github.com/JakeWharton/ThreeTenABP/issues/5
+-dontwarn sun.util.calendar.*


### PR DESCRIPTION
This adds a sample which uses ProGuard and therefore implicitly tests that the library-embedded ProGuard rules work. Without the rules having been applied, ProGuard should fail. A test also asserts that ProGuard has indeed run on the sample and obfuscated a library type.

Closes #4.