### PR TITLE
Deleted init(Application)

### DIFF
--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
@@ -12,10 +12,6 @@ import org.threeten.bp.zone.ZoneRulesProvider;
 public final class AndroidThreeTen {
   private static final AtomicBoolean initialized = new AtomicBoolean();
 
-  public static void init(Application application) {
-    init((Context) application);
-  }
-
   public static void init(Context context) {
     if (initialized.getAndSet(true)) {
       return;


### PR DESCRIPTION
As `Application` is a subclass of `Context` this is not needed.