### PR TITLE
Update threetenbp to v1.3.4 and use ZoneRulesInitializer for on-demand initialization

### DIFF
--- a/threetenabp/build.gradle
+++ b/threetenabp/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-  compile group: 'org.threeten', name: 'threetenbp', version: '1.3.3', classifier: 'no-tzdb'
+  compile group: 'org.threeten', name: 'threetenbp', version: '1.3.4', classifier: 'no-tzdb'
 
   androidTestCompile rootProject.ext.junit
   androidTestCompile rootProject.ext.supportTestRunner

--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
@@ -2,11 +2,14 @@ package com.jakewharton.threetenabp;
 
 import android.app.Application;
 import android.content.Context;
+
+import org.threeten.bp.zone.TzdbZoneRulesProvider;
+import org.threeten.bp.zone.ZoneRulesInitializer;
+import org.threeten.bp.zone.ZoneRulesProvider;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.threeten.bp.zone.TzdbZoneRulesProvider;
-import org.threeten.bp.zone.ZoneRulesProvider;
 
 /** Android-specific initializer for the JSR-310 library. */
 public final class AndroidThreeTen {
@@ -16,28 +19,33 @@ public final class AndroidThreeTen {
     init((Context) application);
   }
 
-  public static void init(Context context) {
+  public static void init(final Context context) {
     if (initialized.getAndSet(true)) {
       return;
     }
 
-    TzdbZoneRulesProvider provider;
-    InputStream is = null;
-    try {
-      is = context.getAssets().open("org/threeten/bp/TZDB.dat");
-      provider = new TzdbZoneRulesProvider(is);
-    } catch (IOException e) {
-      throw new IllegalStateException("TZDB.dat missing from assets.", e);
-    } finally {
-      if (is != null) {
+    ZoneRulesInitializer.setInitializer(new ZoneRulesInitializer() {
+      @Override
+      protected void initializeProviders() {
+        TzdbZoneRulesProvider provider;
+        InputStream is = null;
         try {
-          is.close();
-        } catch (IOException ignored) {
+          is = context.getAssets().open("org/threeten/bp/TZDB.dat");
+          provider = new TzdbZoneRulesProvider(is);
+        } catch (IOException e) {
+          throw new IllegalStateException("TZDB.dat missing from assets.", e);
+        } finally {
+          if (is != null) {
+            try {
+              is.close();
+            } catch (IOException ignored) {
+            }
+          }
         }
-      }
-    }
 
-    ZoneRulesProvider.registerProvider(provider);
+        ZoneRulesProvider.registerProvider(provider);
+      }
+    });
   }
 
   private AndroidThreeTen() {


### PR DESCRIPTION
With this change, almost nothing will need to happen at application startup - the initializer (along with the application context) will be registered, but any other library code execution will be deferred until ZoneRulesProvider is initialized when ThreeTenBP first needs to make use of time zone data later on in execution. Most notably, this prevents ServiceLoader from being used to try to load time zone data, as that was a big performance hit within ThreeTenBP before on Android devices.