### PR TITLE
Add API to let users specify their own TZDB and add gradle task to download latest TZDB

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,10 +4,11 @@ Releasing
  1. Change the version in `gradle.properties` to a non-SNAPSHOT verson.
  2. Update the `CHANGELOG.md` for the impending release.
  3. Update the `README.md` with the new version.
- 4. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
- 5. `git tag -a X.Y.X -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 6. `./gradlew clean uploadArchives`
- 7. Update the `gradle.properties` to the next SNAPSHOT version.
- 8. `git commit -am "Prepare next development version."`
- 9. `git push && git push --tags`
- 10. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.
+ 4. `./gradlew downloadTZDB` to grab the latest TZDB and `git add .` to add it
+ 5. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
+ 6. `git tag -a X.Y.X -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+ 7. `./gradlew clean uploadArchives`
+ 8. Update the `gradle.properties` to the next SNAPSHOT version.
+ 9. `git commit -am "Prepare next development version."`
+ 10. `git push && git push --tags`
+ 11. Visit [Sonatype Nexus](https://oss.sonatype.org/) and promote the artifact.

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:2.2.3'
+    classpath 'de.undercouch:gradle-download-task:3.3.0'
   }
 }
 
@@ -24,3 +25,12 @@ ext {
   supportTestRules = 'com.android.support.test:rules:0.3'
   robolectric = 'org.robolectric:robolectric:3.2.2'
 }
+
+apply plugin: 'de.undercouch.download'
+import de.undercouch.gradle.tasks.download.Download
+task downloadTZDB(type: Download) {
+    src 'https://github.com/ThreeTen/threetenbp/raw/master/src/main/resources/org/threeten/bp/TZDB.dat'
+    dest 'threetenabp/src/main/assets/org/threeten/bp/TZDB.dat'
+    overwrite true
+}
+

--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
@@ -17,6 +17,10 @@ public final class AndroidThreeTen {
   }
 
   public static void init(Context context) {
+    init(context, "org/threeten/bp/TZDB.dat");
+  }
+
+  public static void init(Context context, String assetPath) {
     if (initialized.getAndSet(true)) {
       return;
     }
@@ -24,10 +28,10 @@ public final class AndroidThreeTen {
     TzdbZoneRulesProvider provider;
     InputStream is = null;
     try {
-      is = context.getAssets().open("org/threeten/bp/TZDB.dat");
+      is = context.getAssets().open(assetPath);
       provider = new TzdbZoneRulesProvider(is);
     } catch (IOException e) {
-      throw new IllegalStateException("TZDB.dat missing from assets.", e);
+      throw new IllegalStateException(assetPath + " missing from assets.", e);
     } finally {
       if (is != null) {
         try {


### PR DESCRIPTION
Add easy way to grab latest TZDB.dat and add to RELEASE steps.
Add method to let users specify a TZDB file in their own assets if they want to be ahead of the library.

Reason for the PR is there are new TZs (e.g. Punta_Arenas) that are in the upstream DB but not updated in this library as quickly.