### PR TITLE
Use ZoneRulesInitializer for on-demand initialization

### DIFF
--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/AndroidThreeTen.java
@@ -2,11 +2,8 @@ package com.jakewharton.threetenabp;
 
 import android.app.Application;
 import android.content.Context;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.threeten.bp.zone.TzdbZoneRulesProvider;
-import org.threeten.bp.zone.ZoneRulesProvider;
+import org.threeten.bp.zone.ZoneRulesInitializer;
 
 /** Android-specific initializer for the JSR-310 library. */
 public final class AndroidThreeTen {
@@ -17,27 +14,9 @@ public final class AndroidThreeTen {
   }
 
   public static void init(Context context) {
-    if (initialized.getAndSet(true)) {
-      return;
+    if (!initialized.getAndSet(true)) {
+      ZoneRulesInitializer.setInitializer(new AssetsZoneRulesInitializer(context));
     }
-
-    TzdbZoneRulesProvider provider;
-    InputStream is = null;
-    try {
-      is = context.getAssets().open("org/threeten/bp/TZDB.dat");
-      provider = new TzdbZoneRulesProvider(is);
-    } catch (IOException e) {
-      throw new IllegalStateException("TZDB.dat missing from assets.", e);
-    } finally {
-      if (is != null) {
-        try {
-          is.close();
-        } catch (IOException ignored) {
-        }
-      }
-    }
-
-    ZoneRulesProvider.registerProvider(provider);
   }
 
   private AndroidThreeTen() {

--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/AssetsZoneRulesInitializer.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/AssetsZoneRulesInitializer.java
@@ -1,0 +1,37 @@
+package com.jakewharton.threetenabp;
+
+import android.content.Context;
+import java.io.IOException;
+import java.io.InputStream;
+import org.threeten.bp.zone.TzdbZoneRulesProvider;
+import org.threeten.bp.zone.ZoneRulesInitializer;
+import org.threeten.bp.zone.ZoneRulesProvider;
+
+final class AssetsZoneRulesInitializer extends ZoneRulesInitializer {
+  private final Context context;
+
+  AssetsZoneRulesInitializer(Context context) {
+    this.context = context;
+  }
+
+  @Override protected void initializeProviders() {
+    TzdbZoneRulesProvider provider;
+
+    InputStream is = null;
+    try {
+      is = context.getAssets().open("org/threeten/bp/TZDB.dat");
+      provider = new TzdbZoneRulesProvider(is);
+    } catch (IOException e) {
+      throw new IllegalStateException("TZDB.dat missing from assets.", e);
+    } finally {
+      if (is != null) {
+        try {
+          is.close();
+        } catch (IOException ignored) {
+        }
+      }
+    }
+
+    ZoneRulesProvider.registerProvider(provider);
+  }
+}


### PR DESCRIPTION
With this change, almost nothing will need to happen at application startup - the initializer (along
with the application context) will be registered, but any other library code execution will be deferred
until ZoneRulesProvider is initialized when ThreeTenBP first needs to make use of time zone data later
on in execution. Most notably, this prevents ServiceLoader from being used to try to load time zone
data, as that was a big performance hit within ThreeTenBP before on Android devices.

Closes #52. Closes #53.