### PR TITLE
Add formatter that respects Android 12-/24-hour clock display setting

### DIFF
--- a/sample/src/main/java/com/jakewharton/threetenabp/sample/Examples.java
+++ b/sample/src/main/java/com/jakewharton/threetenabp/sample/Examples.java
@@ -3,7 +3,14 @@ package com.jakewharton.threetenabp.sample;
 import android.app.Activity;
 import android.os.Bundle;
 import android.widget.TextView;
+
+import com.jakewharton.threetenabp.format.AndroidDateTimeFormatter;
+
 import org.threeten.bp.Instant;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZonedDateTime;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.format.FormatStyle;
 
 import static android.util.TypedValue.COMPLEX_UNIT_SP;
 import static android.view.Gravity.CENTER;
@@ -12,14 +19,20 @@ public final class Examples extends Activity {
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
+    DateTimeFormatter formatter = AndroidDateTimeFormatter.ofLocalizedTime(this);
+
     TextView tv = new TextView(this);
     tv.setGravity(CENTER);
     tv.setTextSize(COMPLEX_UNIT_SP, 20);
-    tv.setText("NOW: " + now());
+    tv.setText("NOW: " + formatter.format(hereAndNow()));
     setContentView(tv);
   }
 
   public Instant now() {
     return Instant.now();
+  }
+
+  public ZonedDateTime hereAndNow() {
+    return ZonedDateTime.ofInstant(now(), ZoneId.systemDefault());
   }
 }

--- a/threetenabp/src/main/java/com/jakewharton/threetenabp/format/AndroidDateTimeFormatter.java
+++ b/threetenabp/src/main/java/com/jakewharton/threetenabp/format/AndroidDateTimeFormatter.java
@@ -1,0 +1,62 @@
+package com.jakewharton.threetenabp.format;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.LocaleList;
+
+import org.threeten.bp.chrono.IsoChronology;
+import org.threeten.bp.format.DateTimeFormatter;
+import org.threeten.bp.format.DateTimeFormatterBuilder;
+import org.threeten.bp.format.FormatStyle;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+/**
+ * Provides Android-specific {@link DateTimeFormatter}s, such as a localized time formatter that
+ * respects the user's 12-/24-hour clock preference.
+ */
+public class AndroidDateTimeFormatter {
+
+    /**
+     * Returns a {@link DateTimeFormatter} that can format the time according to the context's
+     * locale and the user's 12-/24-hour clock preference.
+     * @param context the application context
+     * @return a {@link DateTimeFormatter} that properly formats the time.
+     */
+    public static DateTimeFormatter ofLocalizedTime(Context context) {
+        DateFormat legacyFormat = android.text.format.DateFormat.getTimeFormat(context);
+
+        if (legacyFormat instanceof SimpleDateFormat) {
+            String pattern = ((SimpleDateFormat) legacyFormat).toPattern();
+            return new DateTimeFormatterBuilder()
+                    .appendPattern(pattern)
+                    .toFormatter(extractLocale(context));
+        } else {
+            throw new IllegalArgumentException("Unable to convert DateFormat to DateTimeFormatter");
+        }
+    }
+
+    private static Locale extractLocale(Context context) {
+        Configuration configuration = context.getResources().getConfiguration();
+        Locale locale = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            LocaleList localeList = configuration.getLocales();
+            if (!localeList.isEmpty()) {
+                locale = localeList.get(0);
+            }
+        }
+
+        if (locale == null) {
+            locale = configuration.locale;
+        }
+
+        if (locale == null) {
+            locale = Locale.getDefault();
+        }
+
+        return locale;
+    }
+}


### PR DESCRIPTION
Addresses #16.

Some notes:
* The new method, `AndroidDateTimeFormatter#ofLocalizedTime(Context)`, essentially applies the internal logic of `org.threeten.bp.format.SimpleDateTimeFormatStyleProvider` to the time format provided by `android.text.format.DateFormat.GetTimeFormat(Context)`. It is similar to @rnevet's last solution.
* The class does not support different `FormatStyle`s or date-times because `android.text.format.DateFormat` does not have methods that support those either.
* I did not include the formatter caching mechanism used inside of `org.threeten.bp.format.SimpleDateTimeFormatStyleProvider`, but could if consensus says it's necessary.
* I'm not really sure how to test this; I can't find any way to programatically set the user 12-/24-hour preference in an androidTest, and I'm not even sure how to mock it because `android.text.format.DateFormat` internally uses a class called `LocaleData` which is not available at compile time. Any suggestions for testing?